### PR TITLE
Add release process to the batch file.

### DIFF
--- a/PublishFrance.bat
+++ b/PublishFrance.bat
@@ -269,12 +269,19 @@ echo 12. Publish ZIP
 echo ******************************************************************
 echo .
 
-echo copy /y "%ZIP_FILE%" "%PUBLIC_DIR%"
-copy /y "%ZIP_FILE%" "%PUBLIC_DIR%"
-
-set BACKUP_ZIP_FILE=%PUBLIC_DIR%\%NAME%-Ski-%MYDATE%-%MYREVISION%.zip
-echo copy /y "%ZIP_FILE%" "%BACKUP_ZIP_FILE%"
-copy /y "%ZIP_FILE%" "%BACKUP_ZIP_FILE%"
+for /f "delims=" %%a in ('git describe --tags --exact-match') do (
+    set "TAG=%%a"
+)
+if "%TAG%" == "release" (
+	set ZIP_FILE=%PUBLIC_DIR%\%NAME%-Ski.zip
+	echo copy /y "%ZIP_FILE%" "%PUBLIC_DIR%"
+	copy /y "%ZIP_FILE%" "%PUBLIC_DIR%"
+)
+else (
+	set BACKUP_ZIP_FILE=%PUBLIC_DIR%\%NAME%-Ski-%MYDATE%-%MYREVISION%.zip
+	echo copy /y "%ZIP_FILE%" "%BACKUP_ZIP_FILE%"
+	copy /y "%ZIP_FILE%" "%BACKUP_ZIP_FILE%"
+)
 
 echo copy /y "%TARGET_LOG_FILE%" "%PUBLIC_DIR%"
 copy /y "%TARGET_LOG_FILE%" "%PUBLIC_DIR%"


### PR DESCRIPTION
I've create a condition at the end of the batch file (step 12.) to copy under the name France-Ski.zip only the commits with the tag "release". Therefore there will be no more confusion about what directory clients need to download.  
There are yet 3 different clients to this repository, i think it's better if this could not be a problem anymore.  
WARNING : i could not run the batch on my computer, so be careful with what i wrote. It's an idea more than a code. 