### PR TITLE
New way to find if the last commit has a tag or not. Use of git tag -…

### DIFF
--- a/PublishFrance.bat
+++ b/PublishFrance.bat
@@ -9,16 +9,19 @@ echo .
 
 
 rem Git commands must be here before dir is changed
-git tag -d release
 git pull
 
 for /f "Delims=" %%a In ('git rev-parse HEAD') do set MYREVISION=%%a
 echo MYREVISION=%MYREVISION%
 
-for /f "delims=" %%a in ('git describe --tags') do (
+for /f "delims=" %%a In ('git tag --points-at HEAD') do (
     set "TAG=%%a"
 )
-echo TAG=%TAG%
+if defined TAG (
+    echo TAG
+) else (
+    echo Last commit has no tag
+)
 
 :Step2
 echo ******************************************************************
@@ -277,7 +280,7 @@ echo 12. Publish ZIP
 echo ******************************************************************
 echo .
 
-if "%TAG%" == "release" (
+if defined TAG (
 	set ZIP_FILE=%PUBLIC_DIR%\%NAME%-Ski.zip
 	echo copy /y "%ZIP_FILE%" "%PUBLIC_DIR%"
 	copy /y "%ZIP_FILE%" "%PUBLIC_DIR%"


### PR DESCRIPTION
The Batch haven't work yesterday and today. I don't know if it's because our additions to it, but i've tried to simplify the code, and potentially avoid some of the problems.  
Instead of git describe, which reply with the name of the last tag if the last commit have a tag or with the name of the last tag + the number of commit since them + a hash, i've preferred to use git tag --points-at HEAD which reply with nothing if none tag is fund on the last commit.  
Thus, the tag can be misspell, and mainly, we have no more the need to delete each time the previous tag.
Typically, the tag name will  be now " release + the date". 
I hope this changes will work better. 

I've try everything in bash and it's work well. 